### PR TITLE
Base the Trust GXT 960 on the SH68F881

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ sinowisp write \
 | Model | ISP MD5 | MCU | MCU Label | Tested Read | Tested Write |
 | ----- | ------- | --- | --------- | ----------- | ------------ |
 | [Glorious Model O](https://web.archive.org/web/20220609205659mp_/https://www.gloriousgaming.com/products/glorious-model-o-black) | 46459c31e58194fa076b8ce8fb1f3eaa | SH68F89 | BY8948 | ✅ | ❓ |
-| [Trust GXT 960](https://www.trust.com/en/product/23758-gxt-960-graphin-ultra-lightweight-gaming-mouse) | 620f0b67a91f7f74151bc5be745b7110 | ❓ | BY8801 | ✅ | ❓ |
+| [Trust GXT 960](https://www.trust.com/en/product/23758-gxt-960-graphin-ultra-lightweight-gaming-mouse) | 620f0b67a91f7f74151bc5be745b7110 | SH68F881? | BY8801 | ✅ | ❓ |
 
 ## Bootloader Support
 

--- a/src/device_spec.rs
+++ b/src/device_spec.rs
@@ -271,7 +271,7 @@ pub const DEVICE_TERPORT_TR95: DeviceSpec = DeviceSpec {
 pub const DEVICE_TRUST_GXT_960: DeviceSpec = DeviceSpec {
     vendor_id: 0x145f,
     product_id: 0x02b6,
-    ..DEVICE_BASE_SH68F90
+    ..DEVICE_BASE_SH68F881
 };
 
 pub const DEVICE_WEIKAV_SUGAR65: DeviceSpec = DeviceSpec {


### PR DESCRIPTION
The BY8801 turned out to be a 32K part, not a 64K one.