### PR TITLE
chore: update hidra to 0.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,9 +345,9 @@ checksum = "efb8ae90b8d0165be79ff98d845bebbbc9dfa0295ff2ce86beba525d93b9ba60"
 
 [[package]]
 name = "hidra"
-version = "0.0.2"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1a3e082dff027a9cf7c50357d65e8afbfd6f6592ae23990ac789d9b2153e78"
+checksum = "4861c589ab4c739001e0a62db96286e217561221e838095fcd8d31bf4f155e7b"
 dependencies = [
  "core-foundation-sys",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ required-features = ["cli"]
 # Pure-Rust HID. On macOS/Windows this uses hidra's native per-OS backend; on
 # Linux the nusb backend is auto-selected via the target-specific dependency
 # below (the hidapi `linux-static-libusb` equivalent). wasm uses WebHID.
-hidra = "0.0.2"
+hidra = "0.0.3"
 ihex = "3.0"
 thiserror = "2.0"
 phf = { version = "0.11", features = ["macros"] }
@@ -64,7 +64,7 @@ optional = true
 # On Linux there is no native hidraw path we want; always use hidra's nusb
 # backend. Cargo features are additive, so this is unconditional on Linux.
 [target.'cfg(target_os = "linux")'.dependencies]
-hidra = { version = "0.0.2", features = ["nusb"] }
+hidra = { version = "0.0.3", features = ["nusb"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.17"


### PR DESCRIPTION
Bumps hidra from 0.0.2 to 0.0.3 (both the base dependency and the Linux-only nusb one).

hidra 0.0.3 is a code quality release: the platform backend contract became a real trait, the macOS and nusb input-report queues were unified behind one implementation, a WebHID defect where a single stored `Waker` dropped one of two concurrent readers was fixed, and device metadata is now cached rather than re-read per call.

Its one breaking change is `MainFlags` replacing a bare `u32` in `DescriptorBuilder::{input,output,feature}` and `ReportItemInfo::main_flags`. That is a part of the descriptor API this crate does not use, so no source changes are needed here.

## Verification

Checked on all four target configurations: native, `--features nusb`, `x86_64-unknown-linux-gnu` and `x86_64-pc-windows-msvc`.

Against the published 0.0.3 crate on a real SinoWealth keyboard (`05ac:024f`, SH68F90A):

- `list` reports the same two interfaces and the same `feature_report_ids=[5]`
- `read` produces a byte-identical 61440-byte image, MD5 `b58903ab562fb835fde29c85fbdc291e`

The same image was read on macOS, Linux (nusb backend) and Windows (native backend), and matched the images read through hidra 0.0.2 on each.