### PR TITLE
Base the Zifriend ZA981 on the SH68F902A

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ sinowisp write \
 | Yinren R108 | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A | BYK916 | ✅ | ✅ |
 | Yunzii AL66 | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A | SH68F90AS | ✅ | ✅ |
 | Yunzii AL71 | 2d169670eae0d36eae8188562c1f66e8 | SH68F90A | SH68F90AS | ✅ | ✅ |
-| [Zifriend ZA981](https://www.zifriend.net/products/za981-85-keyboard-98-keys-hot-swappable-green-red-switch-custom-keycap-computer-gaming-usb-wired-rgb-light-led-mechanical-keyboard) | 620f0b67a91f7f74151bc5be745b7110 | SH68F90A | BYK901 | ✅ | ✅ |
+| [Zifriend ZA981](https://www.zifriend.net/products/za981-85-keyboard-98-keys-hot-swappable-green-red-switch-custom-keycap-computer-gaming-usb-wired-rgb-light-led-mechanical-keyboard) | 620f0b67a91f7f74151bc5be745b7110 | SH68F902A | BYK90? | ✅ | ✅ |
 
 ### Mice
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ sinowisp write \
 | Yinren R108 | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A | BYK916 | ✅ | ✅ |
 | Yunzii AL66 | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A | SH68F90AS | ✅ | ✅ |
 | Yunzii AL71 | 2d169670eae0d36eae8188562c1f66e8 | SH68F90A | SH68F90AS | ✅ | ✅ |
-| [Zifriend ZA981](https://www.zifriend.net/products/za981-85-keyboard-98-keys-hot-swappable-green-red-switch-custom-keycap-computer-gaming-usb-wired-rgb-light-led-mechanical-keyboard) | 620f0b67a91f7f74151bc5be745b7110 | SH68F902A | BYK90? | ✅ | ✅ |
+| [Zifriend ZA981](https://www.zifriend.net/products/za981-85-keyboard-98-keys-hot-swappable-green-red-switch-custom-keycap-computer-gaming-usb-wired-rgb-light-led-mechanical-keyboard) | dc3fa423d3281946e0ae781a42a39b82 | SH68F902A | BYK90? | ✅ | ✅ |
 
 ### Mice
 
@@ -139,6 +139,7 @@ sinowisp write \
 | 46459c31e58194fa076b8ce8fb1f3eaa | ok       | ?        | ok    |
 | 620f0b67a91f7f74151bc5be745b7110 | ok       | fail[^1] | ok    |
 | cfc8661da8c9d7e351b36c0a763426aa | ok       | fail[^1] | ok    |
+| dc3fa423d3281946e0ae781a42a39b82 | ok       | ?        | ?     |
 | e57490acebcaabfcff84a0ff013955d9 | ok       | fail[^1] | ok    |
 
 [^1]: macOS does not recognize the composite device as an HID device

--- a/src/device_spec.rs
+++ b/src/device_spec.rs
@@ -1,6 +1,6 @@
 use phf::{phf_map, Map};
 
-use crate::platform_spec::{PlatformSpec, PLATFORM_SH68F881, PLATFORM_SH68F90};
+use crate::platform_spec::{PlatformSpec, PLATFORM_SH68F881, PLATFORM_SH68F90, PLATFORM_SH68F902};
 
 const DEFAULT_ISP_IFACE_NUM: i32 = 1;
 const DEFAULT_ISP_REPORT_ID: u32 = 5;
@@ -34,6 +34,15 @@ pub const DEVICE_BASE_SH68F881: DeviceSpec = DeviceSpec {
     vendor_id: 0x0000,
     product_id: 0x0000,
     platform: PLATFORM_SH68F881,
+    isp_iface_num: DEFAULT_ISP_IFACE_NUM,
+    isp_report_id: DEFAULT_ISP_REPORT_ID,
+    reboot: DEFAULT_REBOOT,
+};
+
+pub const DEVICE_BASE_SH68F902: DeviceSpec = DeviceSpec {
+    vendor_id: 0x0000,
+    product_id: 0x0000,
+    platform: PLATFORM_SH68F902,
     isp_iface_num: DEFAULT_ISP_IFACE_NUM,
     isp_report_id: DEFAULT_ISP_REPORT_ID,
     reboot: DEFAULT_REBOOT,
@@ -314,7 +323,7 @@ pub const DEVICE_YINREN_R108: DeviceSpec = DeviceSpec {
 pub const DEVICE_ZIFRIEND_ZA981: DeviceSpec = DeviceSpec {
     vendor_id: 0x258a,
     product_id: 0x003a,
-    ..DEVICE_BASE_SH68F90
+    ..DEVICE_BASE_SH68F902
 };
 
 pub static DEVICES: Map<&'static str, DeviceSpec> = phf_map! {

--- a/src/platform_spec.rs
+++ b/src/platform_spec.rs
@@ -32,8 +32,8 @@ pub const PLATFORM_SH68F902: PlatformSpec = PlatformSpec {
 };
 
 pub static PLATFORMS: Map<&'static str, PlatformSpec> = phf_map! {
-    "sh68f90" => PLATFORM_SH68F90,
     "sh68f881" => PLATFORM_SH68F881,
+    "sh68f90" => PLATFORM_SH68F90,
     "sh68f902" => PLATFORM_SH68F902,
 };
 

--- a/src/platform_spec.rs
+++ b/src/platform_spec.rs
@@ -26,9 +26,15 @@ pub const PLATFORM_SH68F881: PlatformSpec = PlatformSpec {
     ..PLATFORM_DEFAULT
 };
 
+pub const PLATFORM_SH68F902: PlatformSpec = PlatformSpec {
+    firmware_size: 16384 - PLATFORM_DEFAULT.bootloader_size, // 12288 until bootloader
+    ..PLATFORM_DEFAULT
+};
+
 pub static PLATFORMS: Map<&'static str, PlatformSpec> = phf_map! {
     "sh68f90" => PLATFORM_SH68F90,
     "sh68f881" => PLATFORM_SH68F881,
+    "sh68f902" => PLATFORM_SH68F902,
 };
 
 impl PlatformSpec {


### PR DESCRIPTION
The BYK90? turned out to be a 16K part, not a 64K one, reporting `68f902a000` over ISP. The ISP MD5 recorded for it was just an empty read past the end of the flash, so it's swapped for the actual bootloader hash.