### PR TITLE
Drop the empty bootloader hash and mark uncertain parts with (?)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ sinowisp write \
 | [Aula F87](https://www.aulastar.com/index.php/gaming-keyboard/157.html) | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A | BYK916 | ✅ | ✅ |
 | [CIY X77](https://a.co/d/fKEpeLU) | 46459c31e58194fa076b8ce8fb1f3eaa | SH68F88P (?) | BYK816 | ✅ | ❓ |
 | Deltaco Gaming WK95R | 2d169670eae0d36eae8188562c1f66e8 | SH68F90A | BYK916 | ✅ | ✅ |
-| Dierya DK68SE | ❓ | SH68F90A? | BYK903 | ✅ | ✅ |
+| Dierya DK68SE | ❓ | SH68F90A (?) | BYK903 | ✅ | ✅ |
 | Digital Alliance Meca Warrior X | 2d169670eae0d36eae8188562c1f66e8 | SH68F90 | SH68F90S | ✅ | ✅ |
 | E-Yooso Z11 | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90? | BYK901 | ✅ | ✅ |
 | E-Yooso Z82 | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A | BYK916 | ✅ | ✅ |
@@ -125,7 +125,7 @@ sinowisp write \
 | Model | ISP MD5 | MCU | MCU Label | Tested Read | Tested Write |
 | ----- | ------- | --- | --------- | ----------- | ------------ |
 | [Glorious Model O](https://web.archive.org/web/20220609205659mp_/https://www.gloriousgaming.com/products/glorious-model-o-black) | 46459c31e58194fa076b8ce8fb1f3eaa | SH68F89 | BY8948 | ✅ | ❓ |
-| [Trust GXT 960](https://www.trust.com/en/product/23758-gxt-960-graphin-ultra-lightweight-gaming-mouse) | 13df4ce2933f9654ffef80d6a3c27199 | SH68F881? | BY8801 | ✅ | ❓ |
+| [Trust GXT 960](https://www.trust.com/en/product/23758-gxt-960-graphin-ultra-lightweight-gaming-mouse) | 13df4ce2933f9654ffef80d6a3c27199 | SH68F881 (?) | BY8801 | ✅ | ❓ |
 
 ## Bootloader Support
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ sinowisp write \
 | [Aula F87](https://www.aulastar.com/index.php/gaming-keyboard/157.html) | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A | BYK916 | ✅ | ✅ |
 | [CIY X77](https://a.co/d/fKEpeLU) | 46459c31e58194fa076b8ce8fb1f3eaa | SH68F88P (?) | BYK816 | ✅ | ❓ |
 | Deltaco Gaming WK95R | 2d169670eae0d36eae8188562c1f66e8 | SH68F90A | BYK916 | ✅ | ✅ |
-| Dierya DK68SE | 620f0b67a91f7f74151bc5be745b7110 | SH68F90A | BYK903 | ✅ | ✅ |
+| Dierya DK68SE | ❓ | SH68F90A | BYK903 | ✅ | ✅ |
 | Digital Alliance Meca Warrior X | 2d169670eae0d36eae8188562c1f66e8 | SH68F90 | SH68F90S | ✅ | ✅ |
 | E-Yooso Z11 | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90? | BYK901 | ✅ | ✅ |
 | E-Yooso Z82 | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A | BYK916 | ✅ | ✅ |
@@ -137,7 +137,6 @@ sinowisp write \
 | 2d169670eae0d36eae8188562c1f66e8 | ok       | ?        | ok    |
 | 3e0ebd0c440af5236d7ff8872343f85d | ok       | ok       | ok    |
 | 46459c31e58194fa076b8ce8fb1f3eaa | ok       | ?        | ok    |
-| 620f0b67a91f7f74151bc5be745b7110 | ok       | fail[^1] | ok    |
 | cfc8661da8c9d7e351b36c0a763426aa | ok       | fail[^1] | ok    |
 | dc3fa423d3281946e0ae781a42a39b82 | ok       | ?        | ?     |
 | e57490acebcaabfcff84a0ff013955d9 | ok       | fail[^1] | ok    |

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ sinowisp write \
 | [Aula F87](https://www.aulastar.com/index.php/gaming-keyboard/157.html) | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A | BYK916 | ✅ | ✅ |
 | [CIY X77](https://a.co/d/fKEpeLU) | 46459c31e58194fa076b8ce8fb1f3eaa | SH68F88P (?) | BYK816 | ✅ | ❓ |
 | Deltaco Gaming WK95R | 2d169670eae0d36eae8188562c1f66e8 | SH68F90A | BYK916 | ✅ | ✅ |
-| Dierya DK68SE | ❓ | SH68F90A (?) | BYK903 | ✅ | ✅ |
+| Dierya DK68SE | ❓ | ❓ | BYK903 | ✅ | ✅ |
 | Digital Alliance Meca Warrior X | 2d169670eae0d36eae8188562c1f66e8 | SH68F90 | SH68F90S | ✅ | ✅ |
 | E-Yooso Z11 | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90? | BYK901 | ✅ | ✅ |
 | E-Yooso Z82 | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A | BYK916 | ✅ | ✅ |

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ sinowisp write \
 | Model | ISP MD5 | MCU | MCU Label | Tested Read | Tested Write |
 | ----- | ------- | --- | --------- | ----------- | ------------ |
 | [Glorious Model O](https://web.archive.org/web/20220609205659mp_/https://www.gloriousgaming.com/products/glorious-model-o-black) | 46459c31e58194fa076b8ce8fb1f3eaa | SH68F89 | BY8948 | ✅ | ❓ |
-| [Trust GXT 960](https://www.trust.com/en/product/23758-gxt-960-graphin-ultra-lightweight-gaming-mouse) | 620f0b67a91f7f74151bc5be745b7110 | SH68F881? | BY8801 | ✅ | ❓ |
+| [Trust GXT 960](https://www.trust.com/en/product/23758-gxt-960-graphin-ultra-lightweight-gaming-mouse) | 13df4ce2933f9654ffef80d6a3c27199 | SH68F881? | BY8801 | ✅ | ❓ |
 
 ## Bootloader Support
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ sinowisp write \
 | [Aula F87](https://www.aulastar.com/index.php/gaming-keyboard/157.html) | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A | BYK916 | ✅ | ✅ |
 | [CIY X77](https://a.co/d/fKEpeLU) | 46459c31e58194fa076b8ce8fb1f3eaa | SH68F88P (?) | BYK816 | ✅ | ❓ |
 | Deltaco Gaming WK95R | 2d169670eae0d36eae8188562c1f66e8 | SH68F90A | BYK916 | ✅ | ✅ |
-| Dierya DK68SE | ❓ | SH68F90A | BYK903 | ✅ | ✅ |
+| Dierya DK68SE | ❓ | SH68F90A? | BYK903 | ✅ | ✅ |
 | Digital Alliance Meca Warrior X | 2d169670eae0d36eae8188562c1f66e8 | SH68F90 | SH68F90S | ✅ | ✅ |
 | E-Yooso Z11 | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90? | BYK901 | ✅ | ✅ |
 | E-Yooso Z82 | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A | BYK916 | ✅ | ✅ |


### PR DESCRIPTION
Same story as the ZA981 in #144. The BY8801 is a 32K part, so its bootloader sits at `0x7000-0x7fff` and `620f0b67a91f7f74151bc5be745b7110` was just the empty read past the end of the array. The real bootloader is byte-identical to the Hykker X Range's, so it gets the hash that's already in the table. The DK68SE had the same empty hash but there's no dump to carve a real one from, so both its hash and its part are marked unknown and the empty hash is gone from the platforms list.

While in there, `(?)` now consistently means the whole part is a guess, and a bare `?` means unknown characters. The GXT 960 moves to `(?)` since `SH68F881` has no longer variant a `?` could stand for. The eight `SH68F90?` rows keep their `?` because both SH68F90 and SH68F90A exist, and `BYK90?` keeps its own for the same reason.