### PR TITLE
Warn when a read comes back empty

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -177,6 +177,10 @@ fn err_main() -> Result<(), CLIError> {
                 .map_err(CLIError::from)?;
             let firmware = flasher::read_cycle(&device, section).map_err(CLIError::from)?;
 
+            if firmware.iter().all(|b| *b == 0) {
+                eprintln!("Warning: read {} bytes of zeros.", firmware.len());
+            }
+
             let digest = md5::compute(&firmware);
             eprintln!("MD5: {digest:x}");
 


### PR DESCRIPTION
A read that comes back as all zeros means the section is past the end of the flash, which is how both the ZA981 and the GXT 960 ended up reporting a bootloader hash of 4096 zero bytes. Nothing warned about it, so the hash looked real enough to get written down.