### PR TITLE
trust-gxt-960: mark the mcu as known sh68f881

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ sinowisp write \
 | Model | ISP MD5 | MCU | MCU Label | Tested Read | Tested Write |
 | ----- | ------- | --- | --------- | ----------- | ------------ |
 | [Glorious Model O](https://web.archive.org/web/20220609205659mp_/https://www.gloriousgaming.com/products/glorious-model-o-black) | 46459c31e58194fa076b8ce8fb1f3eaa | SH68F89 | BY8948 | ✅ | ❓ |
-| [Trust GXT 960](https://www.trust.com/en/product/23758-gxt-960-graphin-ultra-lightweight-gaming-mouse) | 13df4ce2933f9654ffef80d6a3c27199 | SH68F881 (?) | BY8801 | ✅ | ❓ |
+| [Trust GXT 960](https://www.trust.com/en/product/23758-gxt-960-graphin-ultra-lightweight-gaming-mouse) | 13df4ce2933f9654ffef80d6a3c27199 | SH68F881 | BY8801 | ✅ | ✅ |
 
 ## Bootloader Support
 


### PR DESCRIPTION
I was able to reverse enough of the stock firmware to recreat enough of the subsystems to read the info region of this device, including the part number. The part number came back as 68f881000 confirming that this is a sh68f881(w)
