### PR TITLE
Fall back between HID backends within a single run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,8 +346,6 @@ checksum = "efb8ae90b8d0165be79ff98d845bebbbc9dfa0295ff2ce86beba525d93b9ba60"
 [[package]]
 name = "hidra"
 version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4861c589ab4c739001e0a62db96286e217561221e838095fcd8d31bf4f155e7b"
 dependencies = [
  "core-foundation-sys",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,6 +346,7 @@ checksum = "efb8ae90b8d0165be79ff98d845bebbbc9dfa0295ff2ce86beba525d93b9ba60"
 [[package]]
 name = "hidra"
 version = "0.0.3"
+source = "git+https://github.com/carlossless/hidra?rev=e11ba204159dfc791c4505ef59a0ce759d500c5b#e11ba204159dfc791c4505ef59a0ce759d500c5b"
 dependencies = [
  "core-foundation-sys",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,8 +345,9 @@ checksum = "efb8ae90b8d0165be79ff98d845bebbbc9dfa0295ff2ce86beba525d93b9ba60"
 
 [[package]]
 name = "hidra"
-version = "0.0.3"
-source = "git+https://github.com/carlossless/hidra?rev=a9bff3926598cb8b0c1f6d39a61846b8d954aa82#a9bff3926598cb8b0c1f6d39a61846b8d954aa82"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ec1c50d216cb0f486f6a48f59f70b0abd18396c8e8178e6e9d210cc59d37bf8"
 dependencies = [
  "core-foundation-sys",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,7 +346,7 @@ checksum = "efb8ae90b8d0165be79ff98d845bebbbc9dfa0295ff2ce86beba525d93b9ba60"
 [[package]]
 name = "hidra"
 version = "0.0.3"
-source = "git+https://github.com/carlossless/hidra?rev=d0e0595e105a47f56f55f1c4ee932a042a1b88ec#d0e0595e105a47f56f55f1c4ee932a042a1b88ec"
+source = "git+https://github.com/carlossless/hidra?rev=a9bff3926598cb8b0c1f6d39a61846b8d954aa82#a9bff3926598cb8b0c1f6d39a61846b8d954aa82"
 dependencies = [
  "core-foundation-sys",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,7 +346,7 @@ checksum = "efb8ae90b8d0165be79ff98d845bebbbc9dfa0295ff2ce86beba525d93b9ba60"
 [[package]]
 name = "hidra"
 version = "0.0.3"
-source = "git+https://github.com/carlossless/hidra?rev=e11ba204159dfc791c4505ef59a0ce759d500c5b#e11ba204159dfc791c4505ef59a0ce759d500c5b"
+source = "git+https://github.com/carlossless/hidra?rev=d0e0595e105a47f56f55f1c4ee932a042a1b88ec#d0e0595e105a47f56f55f1c4ee932a042a1b88ec"
 dependencies = [
  "core-foundation-sys",
  "js-sys",
@@ -523,19 +523,23 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "nusb"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "215a49c10e8cff30a0da93b258b21846c4e9242f7683748cfa8474fdc2e4d22b"
+checksum = "18ef13beb3b3a8fc16fd7aea912ebd3d45dde00a9a5b968d0742297468065845"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
  "futures-core",
  "io-kit-sys",
+ "js-sys",
  "linux-raw-sys",
  "log",
  "once_cell",
  "rustix",
  "slab",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
  "windows-sys 0.61.2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ required-features = ["cli"]
 
 [dependencies]
 # Both backends built in; `DeviceSelector` falls back between them at run time.
-hidra = { version = "0.0.3", features = ["nusb"] }
+hidra = "0.0.3"
 ihex = "3.0"
 thiserror = "2.0"
 phf = { version = "0.11", features = ["macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ cli = [
     "dep:simple_logger",
     "dep:log",
 ]
-# No-op: hidra's nusb backend is always built in and picked at run time.
+# No-op, kept so an existing `--features nusb` still resolves: hidra compiles
+# both backends in and this crate names the one it wants.
 nusb = []
 
 [[bin]]
@@ -36,7 +37,7 @@ required-features = ["cli"]
 
 [dependencies]
 # Both backends built in; `DeviceSelector` falls back between them at run time.
-hidra = "0.0.3"
+hidra = "0.0.4"
 ihex = "3.0"
 thiserror = "2.0"
 phf = { version = "0.11", features = ["macros"] }
@@ -63,7 +64,3 @@ chrono = "0.4.41"
 predicates = "3.1.3"
 serial_test = "3.2.0"
 stdext = "0.3.3"
-
-# TODO: drop once hidra#8 lands and the backend-dispatch API is on crates.io.
-[patch.crates-io]
-hidra = { git = "https://github.com/carlossless/hidra", rev = "a9bff3926598cb8b0c1f6d39a61846b8d954aa82" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,6 @@ predicates = "3.1.3"
 serial_test = "3.2.0"
 stdext = "0.3.3"
 
-# TODO: drop once the backend-dispatch changes are released to crates.io.
+# TODO: drop once hidra#8 lands and the backend-dispatch API is on crates.io.
 [patch.crates-io]
-hidra = { path = "../hidra" }
+hidra = { git = "https://github.com/carlossless/hidra", rev = "e11ba204159dfc791c4505ef59a0ce759d500c5b" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,4 +66,4 @@ stdext = "0.3.3"
 
 # TODO: drop once hidra#8 lands and the backend-dispatch API is on crates.io.
 [patch.crates-io]
-hidra = { git = "https://github.com/carlossless/hidra", rev = "e11ba204159dfc791c4505ef59a0ce759d500c5b" }
+hidra = { git = "https://github.com/carlossless/hidra", rev = "d0e0595e105a47f56f55f1c4ee932a042a1b88ec" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,4 +66,4 @@ stdext = "0.3.3"
 
 # TODO: drop once hidra#8 lands and the backend-dispatch API is on crates.io.
 [patch.crates-io]
-hidra = { git = "https://github.com/carlossless/hidra", rev = "d0e0595e105a47f56f55f1c4ee932a042a1b88ec" }
+hidra = { git = "https://github.com/carlossless/hidra", rev = "a9bff3926598cb8b0c1f6d39a61846b8d954aa82" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,8 @@ cli = [
     "dep:simple_logger",
     "dep:log",
 ]
-# Switch hidra to its nusb-based USB backend instead of the per-OS native one.
-# Linux always uses nusb (auto-selected via the target-specific dependency
-# below); this feature exists to opt into nusb on macOS/Windows as well.
-nusb = ["hidra/nusb"]
+# No-op: hidra's nusb backend is always built in and picked at run time.
+nusb = []
 
 [[bin]]
 name = "sinowisp"
@@ -37,10 +35,8 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-# Pure-Rust HID. On macOS/Windows this uses hidra's native per-OS backend; on
-# Linux the nusb backend is auto-selected via the target-specific dependency
-# below (the hidapi `linux-static-libusb` equivalent). wasm uses WebHID.
-hidra = "0.0.3"
+# Both backends built in; `DeviceSelector` falls back between them at run time.
+hidra = { version = "0.0.3", features = ["nusb"] }
 ihex = "3.0"
 thiserror = "2.0"
 phf = { version = "0.11", features = ["macros"] }
@@ -61,14 +57,13 @@ default-features = false
 features = ["stderr", "colors", "timestamps"]
 optional = true
 
-# On Linux there is no native hidraw path we want; always use hidra's nusb
-# backend. Cargo features are additive, so this is unconditional on Linux.
-[target.'cfg(target_os = "linux")'.dependencies]
-hidra = { version = "0.0.3", features = ["nusb"] }
-
 [dev-dependencies]
 assert_cmd = "2.0.17"
 chrono = "0.4.41"
 predicates = "3.1.3"
 serial_test = "3.2.0"
 stdext = "0.3.3"
+
+# TODO: drop once the backend-dispatch changes are released to crates.io.
+[patch.crates-io]
+hidra = { path = "../hidra" }

--- a/src/device_selector.rs
+++ b/src/device_selector.rs
@@ -49,12 +49,9 @@ pub struct DeviceSelector {
 
 impl DeviceSelector {
     pub fn new() -> Result<Self, DeviceSelectorError> {
-        let backends: Vec<Backend> = [Backend::Native, Backend::Nusb]
-            .into_iter()
-            .filter(|b| b.is_available())
-            .collect();
+        let backends: Vec<Backend> = Backend::available().collect();
         let backend = 0;
-        let api = Self::open_api(backends[backend])?;
+        let api = Self::open_api(backends.first().copied().unwrap_or_default())?;
         Ok(Self {
             api,
             backends,

--- a/src/device_selector.rs
+++ b/src/device_selector.rs
@@ -3,7 +3,8 @@ use std::{thread, time::Duration};
 
 use hidparser::parse_report_descriptor;
 use hidra::{
-    BusType, DeviceInfo, HidDevice, HidError, Hidra, MaybeFuture, MAX_REPORT_DESCRIPTOR_SIZE,
+    Backend, BusType, DeviceInfo, HidDevice, HidError, Hidra, MaybeFuture,
+    MAX_REPORT_DESCRIPTOR_SIZE,
 };
 use indicatif::ProgressBar;
 use itertools::Itertools;
@@ -42,17 +43,53 @@ pub enum DeviceSelectorError {
 
 pub struct DeviceSelector {
     api: Hidra,
+    backends: Vec<Backend>,
+    backend: usize,
 }
 
 impl DeviceSelector {
     pub fn new() -> Result<Self, DeviceSelectorError> {
-        let api = Hidra::new().map_err(DeviceSelectorError::from)?;
+        let backends: Vec<Backend> = [Backend::Native, Backend::Nusb]
+            .into_iter()
+            .filter(|b| b.is_available())
+            .collect();
+        let backend = 0;
+        let api = Self::open_api(backends[backend])?;
+        Ok(Self {
+            api,
+            backends,
+            backend,
+        })
+    }
 
-        // hidra only exposes this on the native macOS backend (not nusb).
-        #[cfg(all(target_os = "macos", not(feature = "nusb")))]
-        api.set_open_exclusive(false); // macOS will throw a privilege violation error otherwise
+    fn open_api(backend: Backend) -> Result<Hidra, DeviceSelectorError> {
+        let api = Hidra::builder()
+            .backend(backend)
+            .build()
+            .map_err(DeviceSelectorError::from)?;
 
-        Ok(Self { api })
+        // macOS refuses an exclusive open with a privilege violation.
+        #[cfg(target_os = "macos")]
+        if backend == Backend::Native {
+            api.set_open_exclusive(false)?;
+        }
+
+        Ok(api)
+    }
+
+    /// Next backend: each sees devices the other cannot, and ISP mode swaps which.
+    fn rotate_backend(&mut self) -> Result<(), DeviceSelectorError> {
+        if self.backends.len() < 2 {
+            return self
+                .api
+                .refresh_devices()
+                .map_err(DeviceSelectorError::from);
+        }
+        self.backend = (self.backend + 1) % self.backends.len();
+        let backend = self.backends[self.backend];
+        info!("Trying the {backend} backend...");
+        self.api = Self::open_api(backend)?;
+        Ok(())
     }
 
     fn sorted_usb_device_list(&self) -> Vec<&DeviceInfo> {
@@ -376,7 +413,7 @@ impl DeviceSelector {
             if attempt > 1 {
                 bar.set_message(format!("Retrying... Attempt {attempt}/{retries}"));
                 info!("Retrying... Attempt {attempt}/{retries}");
-                self.api.refresh_devices()?;
+                self.rotate_backend()?;
                 thread::sleep(time::Duration::from_millis(1000));
             }
 

--- a/src/device_selector.rs
+++ b/src/device_selector.rs
@@ -3,13 +3,12 @@ use std::{thread, time::Duration};
 
 use hidparser::parse_report_descriptor;
 use hidra::{
-    Backend, BusType, DeviceInfo, HidDevice, HidError, Hidra, MaybeFuture,
-    MAX_REPORT_DESCRIPTOR_SIZE,
+    BusType, DeviceInfo, HidError, Hidra, MaybeFuture, Native, Nusb, MAX_REPORT_DESCRIPTOR_SIZE,
 };
 use indicatif::ProgressBar;
 use itertools::Itertools;
 use log::{debug, error, info};
-use sinowisp::{is_expected_error, DeviceSpec, ISPDevice};
+use sinowisp::{is_expected_error, DeviceSpec, ISPDevice, IspHandle};
 use thiserror::Error;
 
 use crate::hid_tree::{DeviceNode, InterfaceNode};
@@ -41,51 +40,90 @@ pub enum DeviceSelectorError {
     UnexpectedDeviceCount,
 }
 
+/// The two hidra backends, so one field can hold either.
+///
+/// Backends are types, so this is the caller's to declare. It forwards the
+/// three methods the selector uses; each sees devices the other cannot, and
+/// ISP mode swaps which.
+enum Api {
+    Native(Hidra<Native>),
+    Nusb(Hidra<Nusb>),
+}
+
+impl Api {
+    fn open(which: Backend) -> Result<Self, DeviceSelectorError> {
+        Ok(match which {
+            Backend::Native => {
+                let api = Hidra::<Native>::builder().build()?;
+                // macOS refuses an exclusive open with a privilege violation.
+                #[cfg(target_os = "macos")]
+                api.set_open_exclusive(false);
+                Api::Native(api)
+            }
+            Backend::Nusb => Api::Nusb(Hidra::<Nusb>::builder().build()?),
+        })
+    }
+
+    fn refresh_devices(&mut self) -> Result<(), DeviceSelectorError> {
+        match self {
+            Api::Native(api) => api.refresh_devices()?,
+            Api::Nusb(api) => api.refresh_devices()?,
+        }
+        Ok(())
+    }
+
+    fn device_list(&self) -> Vec<&DeviceInfo> {
+        match self {
+            Api::Native(api) => api.device_list().collect(),
+            Api::Nusb(api) => api.device_list().collect(),
+        }
+    }
+
+    fn open_path(&self, path: &str) -> Result<IspHandle, DeviceSelectorError> {
+        Ok(match self {
+            Api::Native(api) => IspHandle::from(api.open_path(path).wait()?),
+            Api::Nusb(api) => IspHandle::from(api.open_path(path).wait()?),
+        })
+    }
+}
+
+/// Which backend to open. `Api` is the value; this is the choice.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum Backend {
+    Native,
+    Nusb,
+}
+
+impl core::fmt::Display for Backend {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(match self {
+            Backend::Native => "native",
+            Backend::Nusb => "nusb",
+        })
+    }
+}
+
+const BACKENDS: [Backend; 2] = [Backend::Native, Backend::Nusb];
+
 pub struct DeviceSelector {
-    api: Hidra,
-    backends: Vec<Backend>,
+    api: Api,
     backend: usize,
 }
 
 impl DeviceSelector {
     pub fn new() -> Result<Self, DeviceSelectorError> {
-        let backends: Vec<Backend> = Backend::available().collect();
-        let backend = 0;
-        let api = Self::open_api(backends.first().copied().unwrap_or_default())?;
         Ok(Self {
-            api,
-            backends,
-            backend,
+            api: Api::open(BACKENDS[0])?,
+            backend: 0,
         })
-    }
-
-    fn open_api(backend: Backend) -> Result<Hidra, DeviceSelectorError> {
-        let api = Hidra::builder()
-            .backend(backend)
-            .build()
-            .map_err(DeviceSelectorError::from)?;
-
-        // macOS refuses an exclusive open with a privilege violation.
-        #[cfg(target_os = "macos")]
-        if backend == Backend::Native {
-            api.set_open_exclusive(false)?;
-        }
-
-        Ok(api)
     }
 
     /// Next backend: each sees devices the other cannot, and ISP mode swaps which.
     fn rotate_backend(&mut self) -> Result<(), DeviceSelectorError> {
-        if self.backends.len() < 2 {
-            return self
-                .api
-                .refresh_devices()
-                .map_err(DeviceSelectorError::from);
-        }
-        self.backend = (self.backend + 1) % self.backends.len();
-        let backend = self.backends[self.backend];
+        self.backend = (self.backend + 1) % BACKENDS.len();
+        let backend = BACKENDS[self.backend];
         info!("Trying the {backend} backend...");
-        self.api = Self::open_api(backend)?;
+        self.api = Api::open(backend)?;
         Ok(())
     }
 
@@ -93,6 +131,7 @@ impl DeviceSelector {
         let mut devices: Vec<_> = self
             .api
             .device_list()
+            .into_iter()
             .filter(|d| d.bus_type() == BusType::Usb)
             .collect();
         // TODO: move out the platform specific sorting
@@ -134,17 +173,13 @@ impl DeviceSelector {
         &self,
         path: &str,
     ) -> Result<Vec<u32>, DeviceSelectorError> {
-        let dev = self
-            .api
-            .open_path(path)
-            .wait()
-            .map_err(DeviceSelectorError::from)?;
+        let dev = self.api.open_path(path)?;
         self.get_feature_report_ids_from_device(&dev)
     }
 
     fn get_feature_report_ids_from_device(
         &self,
-        dev: &HidDevice,
+        dev: &IspHandle,
     ) -> Result<Vec<u32>, DeviceSelectorError> {
         let mut buf: [u8; MAX_REPORT_DESCRIPTOR_SIZE] = [0; MAX_REPORT_DESCRIPTOR_SIZE];
         let size: usize = dev
@@ -170,7 +205,7 @@ impl DeviceSelector {
         Ok(res)
     }
 
-    fn get_report_descriptor(&self, dev: &HidDevice) -> Result<Vec<u8>, DeviceSelectorError> {
+    fn get_report_descriptor(&self, dev: &IspHandle) -> Result<Vec<u8>, DeviceSelectorError> {
         let mut buf: [u8; MAX_REPORT_DESCRIPTOR_SIZE] = [0; MAX_REPORT_DESCRIPTOR_SIZE];
         let size: usize = dev
             .get_report_descriptor(&mut buf)
@@ -188,7 +223,7 @@ impl DeviceSelector {
     ) {
         let descriptor: Result<Vec<u8>, DeviceSelectorError>;
         let feature_report_ids: Result<Vec<u32>, DeviceSelectorError>;
-        match self.api.open_path(path).wait() {
+        match self.api.open_path(path) {
             Ok(ref dev) => {
                 descriptor = self.get_report_descriptor(dev);
                 match descriptor {
@@ -201,7 +236,7 @@ impl DeviceSelector {
                 }
             }
             Err(err) => {
-                descriptor = Err(DeviceSelectorError::from(err));
+                descriptor = Err(err);
                 feature_report_ids = Err(DeviceSelectorError::NotFound);
             }
         }
@@ -289,11 +324,7 @@ impl DeviceSelector {
             )?;
             debug!("ISP device: {}", device.info());
 
-            let handle = self
-                .api
-                .open_path(device.path())
-                .wait()
-                .map_err(DeviceSelectorError::from)?;
+            let handle = self.api.open_path(device.path())?;
 
             Ok(ISPDevice::new(device_spec, handle, None))
         };
@@ -311,22 +342,14 @@ impl DeviceSelector {
             let xfer_device = devices[1];
             debug!("ISP XFER device: {}", xfer_device.info());
 
-            let cmd_handle = self
-                .api
-                .open_path(cmd_device.path())
-                .wait()
-                .map_err(DeviceSelectorError::from)?;
-            let xfer_handle = self
-                .api
-                .open_path(xfer_device.path())
-                .wait()
-                .map_err(DeviceSelectorError::from)?;
+            let cmd_handle = self.api.open_path(cmd_device.path())?;
+            let xfer_handle = self.api.open_path(xfer_device.path())?;
 
             Ok(ISPDevice::new(device_spec, cmd_handle, Some(xfer_handle)))
         };
     }
 
-    fn find_device(&self, device_spec: DeviceSpec) -> Result<HidDevice, DeviceSelectorError> {
+    fn find_device(&self, device_spec: DeviceSpec) -> Result<IspHandle, DeviceSelectorError> {
         let filtered_devices = self.unique_usb_device_list().into_iter().filter(|d| {
             d.vendor_id() == device_spec.vendor_id
                 && d.product_id() == device_spec.product_id
@@ -351,17 +374,13 @@ impl DeviceSelector {
         };
 
         debug!("Opening: {:?}", cmd_device_info.path());
-        let device = self
-            .api
-            .open_path(cmd_device_info.path())
-            .wait()
-            .map_err(DeviceSelectorError::from)?;
+        let device = self.api.open_path(cmd_device_info.path())?;
         Ok(device)
     }
 
     fn switch_to_isp_device(
         &mut self,
-        device: HidDevice,
+        device: IspHandle,
         device_spec: DeviceSpec,
     ) -> Result<ISPDevice, DeviceSelectorError> {
         if let Err(err) = self.enter_isp_mode(&device) {
@@ -452,7 +471,7 @@ impl DeviceSelector {
         Err(DeviceSelectorError::NotFound)
     }
 
-    fn enter_isp_mode(&self, handle: &HidDevice) -> Result<(), DeviceSelectorError> {
+    fn enter_isp_mode(&self, handle: &IspHandle) -> Result<(), DeviceSelectorError> {
         let cmd: [u8; COMMAND_LENGTH] = [REPORT_ID_ISP, CMD_ISP_MODE, 0x00, 0x00, 0x00, 0x00];
         handle.send_feature_report(&cmd).wait()?;
         Ok(())

--- a/src/device_selector.rs
+++ b/src/device_selector.rs
@@ -8,7 +8,7 @@ use hidra::{
 use indicatif::ProgressBar;
 use itertools::Itertools;
 use log::{debug, error, info};
-use sinowisp::{is_expected_error, DeviceSpec, ISPDevice, IspHandle};
+use sinowisp::{is_expected_error, DeviceSpec, ISPDevice, ISPHandle};
 use thiserror::Error;
 
 use crate::hid_tree::{DeviceNode, InterfaceNode};
@@ -79,10 +79,10 @@ impl Api {
         }
     }
 
-    fn open_path(&self, path: &str) -> Result<IspHandle, DeviceSelectorError> {
+    fn open_path(&self, path: &str) -> Result<ISPHandle, DeviceSelectorError> {
         Ok(match self {
-            Api::Native(api) => IspHandle::from(api.open_path(path).wait()?),
-            Api::Nusb(api) => IspHandle::from(api.open_path(path).wait()?),
+            Api::Native(api) => ISPHandle::from(api.open_path(path).wait()?),
+            Api::Nusb(api) => ISPHandle::from(api.open_path(path).wait()?),
         })
     }
 }
@@ -179,7 +179,7 @@ impl DeviceSelector {
 
     fn get_feature_report_ids_from_device(
         &self,
-        dev: &IspHandle,
+        dev: &ISPHandle,
     ) -> Result<Vec<u32>, DeviceSelectorError> {
         let mut buf: [u8; MAX_REPORT_DESCRIPTOR_SIZE] = [0; MAX_REPORT_DESCRIPTOR_SIZE];
         let size: usize = dev
@@ -205,7 +205,7 @@ impl DeviceSelector {
         Ok(res)
     }
 
-    fn get_report_descriptor(&self, dev: &IspHandle) -> Result<Vec<u8>, DeviceSelectorError> {
+    fn get_report_descriptor(&self, dev: &ISPHandle) -> Result<Vec<u8>, DeviceSelectorError> {
         let mut buf: [u8; MAX_REPORT_DESCRIPTOR_SIZE] = [0; MAX_REPORT_DESCRIPTOR_SIZE];
         let size: usize = dev
             .get_report_descriptor(&mut buf)
@@ -349,7 +349,7 @@ impl DeviceSelector {
         };
     }
 
-    fn find_device(&self, device_spec: DeviceSpec) -> Result<IspHandle, DeviceSelectorError> {
+    fn find_device(&self, device_spec: DeviceSpec) -> Result<ISPHandle, DeviceSelectorError> {
         let filtered_devices = self.unique_usb_device_list().into_iter().filter(|d| {
             d.vendor_id() == device_spec.vendor_id
                 && d.product_id() == device_spec.product_id
@@ -380,7 +380,7 @@ impl DeviceSelector {
 
     fn switch_to_isp_device(
         &mut self,
-        device: IspHandle,
+        device: ISPHandle,
         device_spec: DeviceSpec,
     ) -> Result<ISPDevice, DeviceSelectorError> {
         if let Err(err) = self.enter_isp_mode(&device) {
@@ -471,7 +471,7 @@ impl DeviceSelector {
         Err(DeviceSelectorError::NotFound)
     }
 
-    fn enter_isp_mode(&self, handle: &IspHandle) -> Result<(), DeviceSelectorError> {
+    fn enter_isp_mode(&self, handle: &ISPHandle) -> Result<(), DeviceSelectorError> {
         let cmd: [u8; COMMAND_LENGTH] = [REPORT_ID_ISP, CMD_ISP_MODE, 0x00, 0x00, 0x00, 0x00];
         handle.send_feature_report(&cmd).wait()?;
         Ok(())

--- a/src/isp_device.rs
+++ b/src/isp_device.rs
@@ -28,7 +28,7 @@ const XFER_WRITE_PAGE: u8 = 0x77;
 /// protocol needs three methods and this forwards them. On wasm there is only
 /// WebHID, so it is a plain newtype.
 #[cfg(not(target_arch = "wasm32"))]
-pub enum IspHandle {
+pub enum ISPHandle {
     /// A handle on the per-OS backend.
     Native(HidDevice<NativeDevice>),
     /// A handle on the raw-USB backend.
@@ -37,26 +37,26 @@ pub enum IspHandle {
 
 /// A HID handle an [`ISPDevice`] talks through.
 #[cfg(target_arch = "wasm32")]
-pub struct IspHandle(HidDevice);
+pub struct ISPHandle(HidDevice);
 
 #[cfg(not(target_arch = "wasm32"))]
-impl From<HidDevice<NativeDevice>> for IspHandle {
+impl From<HidDevice<NativeDevice>> for ISPHandle {
     fn from(device: HidDevice<NativeDevice>) -> Self {
-        IspHandle::Native(device)
+        ISPHandle::Native(device)
     }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-impl From<HidDevice<NusbDevice>> for IspHandle {
+impl From<HidDevice<NusbDevice>> for ISPHandle {
     fn from(device: HidDevice<NusbDevice>) -> Self {
-        IspHandle::Nusb(device)
+        ISPHandle::Nusb(device)
     }
 }
 
 #[cfg(target_arch = "wasm32")]
-impl From<HidDevice> for IspHandle {
+impl From<HidDevice> for ISPHandle {
     fn from(device: HidDevice) -> Self {
-        IspHandle(device)
+        ISPHandle(device)
     }
 }
 
@@ -66,15 +66,15 @@ macro_rules! forward {
     ($self:ident, $call:ident($($arg:expr),*)) => {{
         #[cfg(not(target_arch = "wasm32"))]
         match $self {
-            IspHandle::Native(d) => d.$call($($arg),*).await,
-            IspHandle::Nusb(d) => d.$call($($arg),*).await,
+            ISPHandle::Native(d) => d.$call($($arg),*).await,
+            ISPHandle::Nusb(d) => d.$call($($arg),*).await,
         }
         #[cfg(target_arch = "wasm32")]
         $self.0.$call($($arg),*).await
     }};
 }
 
-impl IspHandle {
+impl ISPHandle {
     pub async fn send_feature_report(&self, data: &[u8]) -> Result<(), HidError> {
         forward!(self, send_feature_report(data))
     }
@@ -95,10 +95,10 @@ impl IspHandle {
 /// read/write cycles (and insert the settle delays after [`erase`](Self::erase)
 /// and [`reboot`](Self::reboot)).
 pub struct ISPDevice {
-    cmd_device: IspHandle,
+    cmd_device: ISPHandle,
     /// Some platforms (Windows) expose the transfer report on a separate HID
     /// handle; everywhere else it is the same handle as `cmd_device`.
-    xfer_device: Option<IspHandle>,
+    xfer_device: Option<ISPHandle>,
     device_spec: DeviceSpec,
 }
 
@@ -157,8 +157,8 @@ impl ISPDevice {
     /// platforms that split them across HID collections (Windows).
     pub fn new(
         device_spec: DeviceSpec,
-        cmd_device: impl Into<IspHandle>,
-        xfer_device: Option<IspHandle>,
+        cmd_device: impl Into<ISPHandle>,
+        xfer_device: Option<ISPHandle>,
     ) -> Self {
         Self {
             cmd_device: cmd_device.into(),
@@ -172,7 +172,7 @@ impl ISPDevice {
         &self.device_spec
     }
 
-    fn xfer_device(&self) -> &IspHandle {
+    fn xfer_device(&self) -> &ISPHandle {
         self.xfer_device.as_ref().unwrap_or(&self.cmd_device)
     }
 

--- a/src/isp_device.rs
+++ b/src/isp_device.rs
@@ -2,6 +2,8 @@ use core::panic;
 use std::str::FromStr;
 
 use hidra::{HidDevice, HidError};
+#[cfg(not(target_arch = "wasm32"))]
+use hidra::{NativeDevice, NusbDevice};
 use thiserror::Error;
 
 use crate::{device_spec::*, VerificationError};
@@ -20,6 +22,72 @@ const CMD_REBOOT: u8 = 0x5a;
 const XFER_READ_PAGE: u8 = 0x72;
 const XFER_WRITE_PAGE: u8 = 0x77;
 
+/// A HID handle an [`ISPDevice`] talks through.
+///
+/// hidra backends are types, so holding either is the caller's job; the
+/// protocol needs three methods and this forwards them. On wasm there is only
+/// WebHID, so it is a plain newtype.
+#[cfg(not(target_arch = "wasm32"))]
+pub enum IspHandle {
+    /// A handle on the per-OS backend.
+    Native(HidDevice<NativeDevice>),
+    /// A handle on the raw-USB backend.
+    Nusb(HidDevice<NusbDevice>),
+}
+
+/// A HID handle an [`ISPDevice`] talks through.
+#[cfg(target_arch = "wasm32")]
+pub struct IspHandle(HidDevice);
+
+#[cfg(not(target_arch = "wasm32"))]
+impl From<HidDevice<NativeDevice>> for IspHandle {
+    fn from(device: HidDevice<NativeDevice>) -> Self {
+        IspHandle::Native(device)
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl From<HidDevice<NusbDevice>> for IspHandle {
+    fn from(device: HidDevice<NusbDevice>) -> Self {
+        IspHandle::Nusb(device)
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl From<HidDevice> for IspHandle {
+    fn from(device: HidDevice) -> Self {
+        IspHandle(device)
+    }
+}
+
+/// Forwards the three methods the protocol needs to whichever backend the
+/// handle came from.
+macro_rules! forward {
+    ($self:ident, $call:ident($($arg:expr),*)) => {{
+        #[cfg(not(target_arch = "wasm32"))]
+        match $self {
+            IspHandle::Native(d) => d.$call($($arg),*).await,
+            IspHandle::Nusb(d) => d.$call($($arg),*).await,
+        }
+        #[cfg(target_arch = "wasm32")]
+        $self.0.$call($($arg),*).await
+    }};
+}
+
+impl IspHandle {
+    pub async fn send_feature_report(&self, data: &[u8]) -> Result<(), HidError> {
+        forward!(self, send_feature_report(data))
+    }
+
+    pub async fn get_report_descriptor(&self, buf: &mut [u8]) -> Result<usize, HidError> {
+        forward!(self, get_report_descriptor(buf))
+    }
+
+    pub async fn get_feature_report(&self, buf: &mut [u8]) -> Result<usize, HidError> {
+        forward!(self, get_feature_report(buf))
+    }
+}
+
 /// One open connection to a device in ISP bootloader mode.
 ///
 /// The methods are the individual protocol operations; they perform no
@@ -27,10 +95,10 @@ const XFER_WRITE_PAGE: u8 = 0x77;
 /// read/write cycles (and insert the settle delays after [`erase`](Self::erase)
 /// and [`reboot`](Self::reboot)).
 pub struct ISPDevice {
-    cmd_device: HidDevice,
+    cmd_device: IspHandle,
     /// Some platforms (Windows) expose the transfer report on a separate HID
     /// handle; everywhere else it is the same handle as `cmd_device`.
-    xfer_device: Option<HidDevice>,
+    xfer_device: Option<IspHandle>,
     device_spec: DeviceSpec,
 }
 
@@ -89,11 +157,11 @@ impl ISPDevice {
     /// platforms that split them across HID collections (Windows).
     pub fn new(
         device_spec: DeviceSpec,
-        cmd_device: HidDevice,
-        xfer_device: Option<HidDevice>,
+        cmd_device: impl Into<IspHandle>,
+        xfer_device: Option<IspHandle>,
     ) -> Self {
         Self {
-            cmd_device,
+            cmd_device: cmd_device.into(),
             xfer_device,
             device_spec,
         }
@@ -104,7 +172,7 @@ impl ISPDevice {
         &self.device_spec
     }
 
-    fn xfer_device(&self) -> &HidDevice {
+    fn xfer_device(&self) -> &IspHandle {
         self.xfer_device.as_ref().unwrap_or(&self.cmd_device)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! Async primitives for the Sinowealth 8051 HID ISP bootloader protocol.
 //!
 //! Each protocol operation ([`ISPDevice::enable_firmware`], [`ISPDevice::erase`],
-//! [`ISPDevice::read_page`], ...) is an `async` method over an [`IspHandle`],
+//! [`ISPDevice::read_page`], ...) is an `async` method over an [`ISPHandle`],
 //! so the exact same code drives a native CLI (by calling
 //! [`hidra::MaybeFuture::wait`] on the returned futures) and a web-based flasher
 //! (by `.await`-ing them on `wasm32` with the WebHID backend).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! Async primitives for the Sinowealth 8051 HID ISP bootloader protocol.
 //!
 //! Each protocol operation ([`ISPDevice::enable_firmware`], [`ISPDevice::erase`],
-//! [`ISPDevice::read_page`], ...) is an `async` method over a [`hidra::HidDevice`],
+//! [`ISPDevice::read_page`], ...) is an `async` method over an [`IspHandle`],
 //! so the exact same code drives a native CLI (by calling
 //! [`hidra::MaybeFuture::wait`] on the returned futures) and a web-based flasher
 //! (by `.await`-ing them on `wasm32` with the WebHID backend).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,6 @@ pub use isp_device::*;
 pub use platform_spec::*;
 pub use util::*;
 
-// hidra types that appear in this crate's public API, re-exported so callers
-// use the same backend-selected types this crate was built against.
+// hidra types in this crate's public API, re-exported so callers get the same
+// ones it was built against.
 pub use hidra::{HidDevice, HidError};


### PR DESCRIPTION
Depends on hidra 0.0.4, where the backend became a type parameter rather than a run-time enum.

Because the two backends are now distinct types, a field that can hold either is this crate's to declare, which is the point: sinowisp is the only consumer that swaps backends mid-run, and doing it here costs far less than the dispatch layer hidra was carrying for everyone.

Two small enums, forwarding only what is actually used:

- **`Api`** in the selector: `open`, `refresh_devices`, `device_list`, `open_path`.
- **`ISPHandle`** in the library: `send_feature_report`, `get_feature_report`, `get_report_descriptor`.

Rotating between backends in the retry loop works exactly as before; each still sees devices the other cannot, and ISP mode still swaps which.

The macOS exclusive-open call is inherent to the native backend now, so `Api::open` makes it in the `Native` arm instead of testing at run time which backend it got. `ISPHandle` is a plain newtype on wasm, where WebHID is the only backend.

## Testing

fmt, clippy, `cargo test --workspace --lib --bins`, the wasm build, `nix build`, and `cargo check --bins` for `x86_64-unknown-linux-gnu`, `x86_64-pc-windows-msvc` and `x86_64-apple-darwin`. The Windows cross-check matters here: that two-handle path is `#[cfg(target_os = "windows")]`, so a Linux build does not compile it, and it needed fixing twice during this change.