### PR TITLE
zifriend-za981 and sh68f902 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ sinowisp write \
 | Yinren R108 | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A | BYK916 | ✅ | ✅ |
 | Yunzii AL66 | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A (?) | SH68F90AS (?) | ✅ | ✅ |
 | Yunzii AL71 | 2d169670eae0d36eae8188562c1f66e8 | SH68F90A | SH68F90AS | ✅ | ✅ |
-| [Zifriend ZA981](https://www.zifriend.net/products/za981-85-keyboard-98-keys-hot-swappable-green-red-switch-custom-keycap-computer-gaming-usb-wired-rgb-light-led-mechanical-keyboard) | dc3fa423d3281946e0ae781a42a39b82 | SH68F902A | BYK90? | ✅ | ✅ |
+| [Zifriend ZA981](https://www.zifriend.net/products/za981-85-keyboard-98-keys-hot-swappable-green-red-switch-custom-keycap-computer-gaming-usb-wired-rgb-light-led-mechanical-keyboard) | 6dac0d2288f2a3d83b5703d979c114ec | SH68F902A | BYK90? | ✅ | ✅ |
 
 ### Mice
 
@@ -137,8 +137,8 @@ sinowisp write \
 | 2d169670eae0d36eae8188562c1f66e8 | ok       | ?        | ok    |
 | 3e0ebd0c440af5236d7ff8872343f85d | ok       | ok       | ok    |
 | 46459c31e58194fa076b8ce8fb1f3eaa | ok       | ?        | ok    |
+| 6dac0d2288f2a3d83b5703d979c114ec | ok       | ?        | ?     |
 | cfc8661da8c9d7e351b36c0a763426aa | ok       | fail[^1] | ok    |
-| dc3fa423d3281946e0ae781a42a39b82 | ok       | ?        | ?     |
 | e57490acebcaabfcff84a0ff013955d9 | ok       | fail[^1] | ok    |
 
 [^1]: macOS does not recognize the composite device as an HID device

--- a/src/platform_spec.rs
+++ b/src/platform_spec.rs
@@ -27,7 +27,9 @@ pub const PLATFORM_SH68F881: PlatformSpec = PlatformSpec {
 };
 
 pub const PLATFORM_SH68F902: PlatformSpec = PlatformSpec {
-    firmware_size: 16384 - PLATFORM_DEFAULT.bootloader_size, // 12288 until bootloader
+    firmware_size: 16384 - 3072, // 13312 until bootloader
+    bootloader_size: 3072,
+    page_size: 1024,
     ..PLATFORM_DEFAULT
 };
 


### PR DESCRIPTION
After inspecting the firmware more closely I noticed that it doesn't follow the same 4kB space/alignment as other parts and is contained in a 3072 block
