### PR TITLE
Undo the 571ea8b3 bootloader's byte skew on ISP transfers

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ sinowisp write \
 | [AOKO K101](https://aokowireless.com/product/k101-usb-c-wired-mechanical-keyboard/) | cfc8661da8c9d7e351b36c0a763426aa | SH68F90A | BYK901 | ✅ | ✅ |
 | [Aula F75](https://www.aulastar.com/gaming-keyboard/176.html) | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A | BYK916 | ✅ | ✅ |
 | [Aula F87](https://www.aulastar.com/index.php/gaming-keyboard/157.html) | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A (?) | BYK916 (?) | ✅ | ✅ |
-| [CIY X77](https://a.co/d/fKEpeLU) | 46459c31e58194fa076b8ce8fb1f3eaa | SH68F88P (?) | BYK816 | ✅ | ❓ |
+| [CIY X77](https://a.co/d/fKEpeLU) | 571ea8b315654c39046e4cc3b1e43777 | SH68F89 (?) | BYK816 | ✅ | ✅ |
 | Deltaco Gaming WK95R | 2d169670eae0d36eae8188562c1f66e8 | SH68F90A | BYK916 | ✅ | ✅ |
 | Dierya DK68SE | ❓ | ❓ | BYK903 | ✅ | ✅ |
 | Digital Alliance Meca Warrior X | 2d169670eae0d36eae8188562c1f66e8 | SH68F90 | SH68F90S | ✅ | ✅ |
@@ -124,7 +124,7 @@ sinowisp write \
 
 | Model | ISP MD5 | MCU | MCU Label | Tested Read | Tested Write |
 | ----- | ------- | --- | --------- | ----------- | ------------ |
-| [Glorious Model O](https://web.archive.org/web/20220609205659mp_/https://www.gloriousgaming.com/products/glorious-model-o-black) | 46459c31e58194fa076b8ce8fb1f3eaa | SH68F89 | BY8948 | ✅ | ❓ |
+| [Glorious Model O](https://web.archive.org/web/20220609205659mp_/https://www.gloriousgaming.com/products/glorious-model-o-black) | 571ea8b315654c39046e4cc3b1e43777 | SH68F89 | BY8948 | ✅ | ✅ |
 | [Trust GXT 960](https://www.trust.com/en/product/23758-gxt-960-graphin-ultra-lightweight-gaming-mouse) | 13df4ce2933f9654ffef80d6a3c27199 | SH68F881 | BY8801 | ✅ | ✅ |
 
 ## Bootloader Support
@@ -136,7 +136,7 @@ sinowisp write \
 | 13df4ce2933f9654ffef80d6a3c27199 | ?        | fail[^1] | ok    |
 | 2d169670eae0d36eae8188562c1f66e8 | ok       | ?        | ok    |
 | 3e0ebd0c440af5236d7ff8872343f85d | ok       | ok       | ok    |
-| 46459c31e58194fa076b8ce8fb1f3eaa | ok       | ?        | ok    |
+| 571ea8b315654c39046e4cc3b1e43777 | ok       | ?        | ok    |
 | 6dac0d2288f2a3d83b5703d979c114ec | ok       | ?        | ?     |
 | cfc8661da8c9d7e351b36c0a763426aa | ok       | fail[^1] | ok    |
 | e57490acebcaabfcff84a0ff013955d9 | ok       | fail[^1] | ok    |

--- a/src/device_spec.rs
+++ b/src/device_spec.rs
@@ -1,10 +1,32 @@
 use phf::{phf_map, Map};
 
-use crate::platform_spec::{PlatformSpec, PLATFORM_SH68F881, PLATFORM_SH68F90, PLATFORM_SH68F902};
+use crate::platform_spec::{
+    PlatformSpec, PLATFORM_SH68F881, PLATFORM_SH68F89, PLATFORM_SH68F90, PLATFORM_SH68F902,
+};
 
 const DEFAULT_ISP_IFACE_NUM: i32 = 1;
 const DEFAULT_ISP_REPORT_ID: u32 = 5;
 const DEFAULT_REBOOT: bool = true;
+
+/// Undoes mangling some ISP bootloaders apply in transit; must invert each other.
+#[derive(Clone, Copy, PartialEq)]
+pub struct IspTransform {
+    pub read: fn(usize, u8) -> u8,
+    pub write: fn(usize, u8) -> u8,
+}
+
+/// Measured against an ICP read of the bootloader region; the two constants differ by 4.
+fn bootloader_571ea8b3_read(offset: usize, byte: u8) -> u8 {
+    if offset < 6 {
+        byte
+    } else {
+        byte.wrapping_sub(0x5e)
+    }
+}
+
+fn bootloader_571ea8b3_write(_offset: usize, byte: u8) -> u8 {
+    byte.wrapping_add(0x5a)
+}
 
 #[derive(Clone, Copy, PartialEq)]
 pub struct DeviceSpec {
@@ -19,6 +41,8 @@ pub struct DeviceSpec {
     pub isp_report_id: u32,
 
     pub reboot: bool,
+
+    pub isp_transform: Option<IspTransform>,
 }
 
 pub const DEVICE_BASE_SH68F90: DeviceSpec = DeviceSpec {
@@ -28,6 +52,17 @@ pub const DEVICE_BASE_SH68F90: DeviceSpec = DeviceSpec {
     isp_iface_num: DEFAULT_ISP_IFACE_NUM,
     isp_report_id: DEFAULT_ISP_REPORT_ID,
     reboot: DEFAULT_REBOOT,
+    isp_transform: None,
+};
+
+pub const DEVICE_BASE_SH68F89: DeviceSpec = DeviceSpec {
+    vendor_id: 0x0000,
+    product_id: 0x0000,
+    platform: PLATFORM_SH68F89,
+    isp_iface_num: DEFAULT_ISP_IFACE_NUM,
+    isp_report_id: DEFAULT_ISP_REPORT_ID,
+    reboot: DEFAULT_REBOOT,
+    isp_transform: None,
 };
 
 pub const DEVICE_BASE_SH68F881: DeviceSpec = DeviceSpec {
@@ -37,6 +72,7 @@ pub const DEVICE_BASE_SH68F881: DeviceSpec = DeviceSpec {
     isp_iface_num: DEFAULT_ISP_IFACE_NUM,
     isp_report_id: DEFAULT_ISP_REPORT_ID,
     reboot: DEFAULT_REBOOT,
+    isp_transform: None,
 };
 
 pub const DEVICE_BASE_SH68F902: DeviceSpec = DeviceSpec {
@@ -46,6 +82,7 @@ pub const DEVICE_BASE_SH68F902: DeviceSpec = DeviceSpec {
     isp_iface_num: DEFAULT_ISP_IFACE_NUM,
     isp_report_id: DEFAULT_ISP_REPORT_ID,
     reboot: DEFAULT_REBOOT,
+    isp_transform: None,
 };
 
 pub const DEVICE_AOKO_K101: DeviceSpec = DeviceSpec {
@@ -71,7 +108,11 @@ pub const DEVICE_CIY_X77: DeviceSpec = DeviceSpec {
     vendor_id: 0x258a,
     product_id: 0x0016,
     reboot: false,
-    ..DEVICE_BASE_SH68F881
+    isp_transform: Some(IspTransform {
+        read: bootloader_571ea8b3_read,
+        write: bootloader_571ea8b3_write,
+    }),
+    ..DEVICE_BASE_SH68F89
 };
 
 pub const DEVICE_DELTACO_WK95R: DeviceSpec = DeviceSpec {
@@ -125,7 +166,11 @@ pub const DEVICE_GENESIS_THOR_300_RGB: DeviceSpec = DeviceSpec {
 pub const DEVICE_GLORIOUS_MODEL_O: DeviceSpec = DeviceSpec {
     vendor_id: 0x258a,
     product_id: 0x0036,
-    ..DEVICE_BASE_SH68F90
+    isp_transform: Some(IspTransform {
+        read: bootloader_571ea8b3_read,
+        write: bootloader_571ea8b3_write,
+    }),
+    ..DEVICE_BASE_SH68F89
 };
 
 pub const DEVICE_KZZI_K68PRO: DeviceSpec = DeviceSpec {

--- a/src/isp_device.rs
+++ b/src/isp_device.rs
@@ -162,7 +162,15 @@ impl ISPDevice {
             .get_feature_report(&mut xfer_buf)
             .await
             .map_err(ISPError::from)?;
-        buf.extend_from_slice(&xfer_buf[2..(page_size + 2)]);
+        let page = &xfer_buf[2..(page_size + 2)];
+        match self.device_spec.isp_transform {
+            Some(transform) => buf.extend(
+                page.iter()
+                    .enumerate()
+                    .map(|(i, b)| (transform.read)(i, *b)),
+            ),
+            None => buf.extend_from_slice(page),
+        }
         if xfer_buf[1] != XFER_READ_PAGE {
             return Err(ISPError::ReadWriteMismatch);
         }
@@ -180,7 +188,14 @@ impl ISPDevice {
         let mut xfer_buf: Vec<u8> = vec![0; length];
         xfer_buf[0] = REPORT_ID_XFER;
         xfer_buf[1] = XFER_WRITE_PAGE;
-        xfer_buf[2..length].clone_from_slice(buf);
+        match self.device_spec.isp_transform {
+            Some(transform) => {
+                for (i, (dst, src)) in xfer_buf[2..length].iter_mut().zip(buf).enumerate() {
+                    *dst = (transform.write)(i, *src);
+                }
+            }
+            None => xfer_buf[2..length].clone_from_slice(buf),
+        }
         self.xfer_device()
             .send_feature_report(&xfer_buf)
             .await

--- a/src/platform_spec.rs
+++ b/src/platform_spec.rs
@@ -21,6 +21,11 @@ pub const PLATFORM_SH68F90: PlatformSpec = PlatformSpec {
     ..PLATFORM_DEFAULT
 };
 
+pub const PLATFORM_SH68F89: PlatformSpec = PlatformSpec {
+    firmware_size: 65536 - PLATFORM_DEFAULT.bootloader_size, // 61440 until bootloader
+    ..PLATFORM_DEFAULT
+};
+
 pub const PLATFORM_SH68F881: PlatformSpec = PlatformSpec {
     firmware_size: 32768 - PLATFORM_DEFAULT.bootloader_size, // 28672 until bootloader
     ..PLATFORM_DEFAULT
@@ -34,6 +39,7 @@ pub const PLATFORM_SH68F902: PlatformSpec = PlatformSpec {
 };
 
 pub static PLATFORMS: Map<&'static str, PlatformSpec> = phf_map! {
+    "sh68f89" => PLATFORM_SH68F89,
     "sh68f881" => PLATFORM_SH68F881,
     "sh68f90" => PLATFORM_SH68F90,
     "sh68f902" => PLATFORM_SH68F902,


### PR DESCRIPTION
The particular bootloader found on sh68f89 devices `571ea8b3` mangles modifies payloads in transit: it reads every byte  with 0x5E added to it, except the first 6 of each page, and stores every byte with 0x5A subtracted.

I add an optional IspTransform to DeviceSpec so that cases like this can go through transform functions.

Also adding PLATFORM_SH68F89, and moving the `ciy-x77` onto it - #118 reports it as 64K carrying this same bootloader (same as the `glorious-model-0` which I confirmed the part number through JTAG/ICP).  Using `DEVICE_BASE_SH68F881` for `ciy-x77` was a mistake I accidentally added.