### PR TITLE
Record verified macOS and Windows bootloader support

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,12 +135,12 @@ sinowisp write \
 | ISP MD5                          | MCU                | Size | Windows  | macOS    | Linux |
 | -------------------------------- | ------------------ | ---- | -------- | -------- | ----- |
 | 13df4ce2933f9654ffef80d6a3c27199 | SH68F881           | 4096 | ok       | ok       | ok    |
+| e57490acebcaabfcff84a0ff013955d9 | SH68F881           | 4096 | ok       | ok       | ok    |
+| 571ea8b315654c39046e4cc3b1e43777 | SH68F89            | 4096 | ok       | ok       | ok    |
 | 2d169670eae0d36eae8188562c1f66e8 | SH68F90 / SH68F90A | 4096 | ok       | ok       | ok    |
 | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90 / SH68F90A | 4096 | ok       | ok       | ok    |
-| 571ea8b315654c39046e4cc3b1e43777 | SH68F89            | 4096 | ok       | ok       | ok    |
-| 6dac0d2288f2a3d83b5703d979c114ec | SH68F902A          | 3072 | ok       | ?        | ?     |
 | cfc8661da8c9d7e351b36c0a763426aa | SH68F90 / SH68F90A | 4096 | ok       | ok       | ok    |
-| e57490acebcaabfcff84a0ff013955d9 | SH68F881           | 4096 | ok       | ok       | ok    |
+| 6dac0d2288f2a3d83b5703d979c114ec | SH68F902A          | 3072 | ok       | ?        | ?     |
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -132,15 +132,15 @@ sinowisp write \
 
 ### Platforms
 
-| ISP MD5                          | Windows  | macOS    | Linux |
-| -------------------------------- | -------- | -------- | ----- |
-| 13df4ce2933f9654ffef80d6a3c27199 | ok       | ok       | ok    |
-| 2d169670eae0d36eae8188562c1f66e8 | ok       | ok       | ok    |
-| 3e0ebd0c440af5236d7ff8872343f85d | ok       | ok       | ok    |
-| 571ea8b315654c39046e4cc3b1e43777 | ok       | ok       | ok    |
-| 6dac0d2288f2a3d83b5703d979c114ec | ok       | ?        | ?     |
-| cfc8661da8c9d7e351b36c0a763426aa | ok       | ok       | ok    |
-| e57490acebcaabfcff84a0ff013955d9 | ok       | ok       | ok    |
+| ISP MD5                          | MCU                | Windows  | macOS    | Linux |
+| -------------------------------- | ------------------ | -------- | -------- | ----- |
+| 13df4ce2933f9654ffef80d6a3c27199 | SH68F881           | ok       | ok       | ok    |
+| 2d169670eae0d36eae8188562c1f66e8 | SH68F90 / SH68F90A | ok       | ok       | ok    |
+| 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A           | ok       | ok       | ok    |
+| 571ea8b315654c39046e4cc3b1e43777 | SH68F89            | ok       | ok       | ok    |
+| 6dac0d2288f2a3d83b5703d979c114ec | SH68F902A          | ok       | ?        | ?     |
+| cfc8661da8c9d7e351b36c0a763426aa | SH68F90 / SH68F90A | ok       | ok       | ok    |
+| e57490acebcaabfcff84a0ff013955d9 | SH68F881           | ok       | ok       | ok    |
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ sinowisp write \
 ### Keyboards
 
 | Model | ISP MD5 | MCU | MCU Label | Tested Read | Tested Write |
-| ----- | ------- | --- | --------- | ----------- | ------------ |
+| -------------------------------- | ------------------ | ---- | -------- | -------- | ----- |
 | [AOKO K101](https://aokowireless.com/product/k101-usb-c-wired-mechanical-keyboard/) | cfc8661da8c9d7e351b36c0a763426aa | SH68F90A | BYK901 | ✅ | ✅ |
 | [Aula F75](https://www.aulastar.com/gaming-keyboard/176.html) | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A | BYK916 | ✅ | ✅ |
 | [Aula F87](https://www.aulastar.com/index.php/gaming-keyboard/157.html) | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A (?) | BYK916 (?) | ✅ | ✅ |
@@ -124,7 +124,7 @@ sinowisp write \
 ### Mice
 
 | Model | ISP MD5 | MCU | MCU Label | Tested Read | Tested Write |
-| ----- | ------- | --- | --------- | ----------- | ------------ |
+| -------------------------------- | ------------------ | ---- | -------- | -------- | ----- |
 | [Glorious Model O](https://web.archive.org/web/20220609205659mp_/https://www.gloriousgaming.com/products/glorious-model-o-black) | 571ea8b315654c39046e4cc3b1e43777 | SH68F89 | BY8948 | ✅ | ✅ |
 | [Trust GXT 960](https://www.trust.com/en/product/23758-gxt-960-graphin-ultra-lightweight-gaming-mouse) | 13df4ce2933f9654ffef80d6a3c27199 | SH68F881 | BY8801 | ✅ | ✅ |
 
@@ -132,15 +132,15 @@ sinowisp write \
 
 ### Platforms
 
-| ISP MD5                          | MCU                | Windows  | macOS    | Linux |
-| -------------------------------- | ------------------ | -------- | -------- | ----- |
-| 13df4ce2933f9654ffef80d6a3c27199 | SH68F881           | ok       | ok       | ok    |
-| 2d169670eae0d36eae8188562c1f66e8 | SH68F90 / SH68F90A | ok       | ok       | ok    |
-| 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A           | ok       | ok       | ok    |
-| 571ea8b315654c39046e4cc3b1e43777 | SH68F89            | ok       | ok       | ok    |
-| 6dac0d2288f2a3d83b5703d979c114ec | SH68F902A          | ok       | ?        | ?     |
-| cfc8661da8c9d7e351b36c0a763426aa | SH68F90 / SH68F90A | ok       | ok       | ok    |
-| e57490acebcaabfcff84a0ff013955d9 | SH68F881           | ok       | ok       | ok    |
+| ISP MD5                          | MCU                | Size | Windows  | macOS    | Linux |
+| -------------------------------- | ------------------ | ---- | -------- | -------- | ----- |
+| 13df4ce2933f9654ffef80d6a3c27199 | SH68F881           | 4096 | ok       | ok       | ok    |
+| 2d169670eae0d36eae8188562c1f66e8 | SH68F90 / SH68F90A | 4096 | ok       | ok       | ok    |
+| 3e0ebd0c440af5236d7ff8872343f85d | SH68F90 / SH68F90A | 4096 | ok       | ok       | ok    |
+| 571ea8b315654c39046e4cc3b1e43777 | SH68F89            | 4096 | ok       | ok       | ok    |
+| 6dac0d2288f2a3d83b5703d979c114ec | SH68F902A          | 3072 | ok       | ?        | ?     |
+| cfc8661da8c9d7e351b36c0a763426aa | SH68F90 / SH68F90A | 4096 | ok       | ok       | ok    |
+| e57490acebcaabfcff84a0ff013955d9 | SH68F881           | 4096 | ok       | ok       | ok    |
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -132,15 +132,15 @@ sinowisp write \
 
 ### Platforms
 
-| ISP MD5                          | MCU                | Size | Windows  | macOS    | Linux | Notes                                                       |
-| -------------------------------- | ------------------ | ---- | -------- | -------- | ----- | ----------------------------------------------------------- |
-| 13df4ce2933f9654ffef80d6a3c27199 | SH68F881           | 4096 | ok       | ok       | ok    | byte-identical to `e57490ac` apart from 5 bytes at `0x0fa0` |
-| e57490acebcaabfcff84a0ff013955d9 | SH68F881           | 4096 | ok       | ok       | ok    | byte-identical to `13df4ce2` apart from 5 bytes at `0x0fa0` |
-| 571ea8b315654c39046e4cc3b1e43777 | SH68F89            | 4096 | ok       | ok       | ok    | enumerates as `0603:1021`; requires a byte transform        |
-| 2d169670eae0d36eae8188562c1f66e8 | SH68F90 / SH68F90A | 4096 | ok       | ok       | ok    |                                                             |
-| 3e0ebd0c440af5236d7ff8872343f85d | SH68F90 / SH68F90A | 4096 | ok       | ok       | ok    | only bootloader with USB strings (`Gaming KB`)              |
-| cfc8661da8c9d7e351b36c0a763426aa | SH68F90 / SH68F90A | 4096 | ok       | ok       | ok    |                                                             |
-| 6dac0d2288f2a3d83b5703d979c114ec | SH68F902A          | 3072 | ok       | ?        | ?     | `2d169670` relinked to a 0x3000 base                        |
+| ISP MD5                          | MCU                | Size | Windows  | macOS    | Linux | Notes                                                                       |
+| -------------------------------- | ------------------ | ---- | -------- | -------- | ----- | --------------------------------------------------------------------------- |
+| 13df4ce2933f9654ffef80d6a3c27199 | SH68F881           | 4096 | ok       | ok       | ok    | byte-identical to `e57490ac` apart from 5 bytes at `0x0fa0`                 |
+| e57490acebcaabfcff84a0ff013955d9 | SH68F881           | 4096 | ok       | ok       | ok    | byte-identical to `13df4ce2` apart from 5 bytes at `0x0fa0`                 |
+| 571ea8b315654c39046e4cc3b1e43777 | SH68F89            | 4096 | ok       | ok       | ok    | enumerates as `0603:1021`; requires a byte transform                        |
+| 2d169670eae0d36eae8188562c1f66e8 | SH68F90 / SH68F90A | 4096 | ok       | ok       | ok    |                                                                             |
+| 3e0ebd0c440af5236d7ff8872343f85d | SH68F90 / SH68F90A | 4096 | ok       | ok       | ok    | only bootloader with USB strings (`Gaming KB`) and an interrupt IN endpoint |
+| cfc8661da8c9d7e351b36c0a763426aa | SH68F90 / SH68F90A | 4096 | ok       | ok       | ok    |                                                                             |
+| 6dac0d2288f2a3d83b5703d979c114ec | SH68F902A          | 3072 | ok       | ?        | ?     | `2d169670` relinked to a 0x3000 base                                        |
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -132,15 +132,15 @@ sinowisp write \
 
 ### Platforms
 
-| ISP MD5                          | MCU                | Size | Windows  | macOS    | Linux |
-| -------------------------------- | ------------------ | ---- | -------- | -------- | ----- |
-| 13df4ce2933f9654ffef80d6a3c27199 | SH68F881           | 4096 | ok       | ok       | ok    |
-| e57490acebcaabfcff84a0ff013955d9 | SH68F881           | 4096 | ok       | ok       | ok    |
-| 571ea8b315654c39046e4cc3b1e43777 | SH68F89            | 4096 | ok       | ok       | ok    |
-| 2d169670eae0d36eae8188562c1f66e8 | SH68F90 / SH68F90A | 4096 | ok       | ok       | ok    |
-| 3e0ebd0c440af5236d7ff8872343f85d | SH68F90 / SH68F90A | 4096 | ok       | ok       | ok    |
-| cfc8661da8c9d7e351b36c0a763426aa | SH68F90 / SH68F90A | 4096 | ok       | ok       | ok    |
-| 6dac0d2288f2a3d83b5703d979c114ec | SH68F902A          | 3072 | ok       | ?        | ?     |
+| ISP MD5                          | MCU                | Size | Windows  | macOS    | Linux | Notes                                                       |
+| -------------------------------- | ------------------ | ---- | -------- | -------- | ----- | ----------------------------------------------------------- |
+| 13df4ce2933f9654ffef80d6a3c27199 | SH68F881           | 4096 | ok       | ok       | ok    | byte-identical to `e57490ac` apart from 5 bytes at `0x0fa0` |
+| e57490acebcaabfcff84a0ff013955d9 | SH68F881           | 4096 | ok       | ok       | ok    | byte-identical to `13df4ce2` apart from 5 bytes at `0x0fa0` |
+| 571ea8b315654c39046e4cc3b1e43777 | SH68F89            | 4096 | ok       | ok       | ok    | enumerates as `0603:1021`; requires a byte transform        |
+| 2d169670eae0d36eae8188562c1f66e8 | SH68F90 / SH68F90A | 4096 | ok       | ok       | ok    |                                                             |
+| 3e0ebd0c440af5236d7ff8872343f85d | SH68F90 / SH68F90A | 4096 | ok       | ok       | ok    | only bootloader with USB strings (`Gaming KB`)              |
+| cfc8661da8c9d7e351b36c0a763426aa | SH68F90 / SH68F90A | 4096 | ok       | ok       | ok    |                                                             |
+| 6dac0d2288f2a3d83b5703d979c114ec | SH68F902A          | 3072 | ok       | ?        | ?     | `2d169670` relinked to a 0x3000 base                        |
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -134,13 +134,13 @@ sinowisp write \
 
 | ISP MD5                          | Windows  | macOS    | Linux |
 | -------------------------------- | -------- | -------- | ----- |
-| 13df4ce2933f9654ffef80d6a3c27199 | ?        | fail[^1] | ok    |
+| 13df4ce2933f9654ffef80d6a3c27199 | ok       | ok       | ok    |
 | 2d169670eae0d36eae8188562c1f66e8 | ok       | ?        | ok    |
 | 3e0ebd0c440af5236d7ff8872343f85d | ok       | ok       | ok    |
-| 571ea8b315654c39046e4cc3b1e43777 | ok       | ?        | ok    |
+| 571ea8b315654c39046e4cc3b1e43777 | ok       | ok       | ok    |
 | 6dac0d2288f2a3d83b5703d979c114ec | ok       | ?        | ?     |
 | cfc8661da8c9d7e351b36c0a763426aa | ok       | fail[^1] | ok    |
-| e57490acebcaabfcff84a0ff013955d9 | ok       | fail[^1] | ok    |
+| e57490acebcaabfcff84a0ff013955d9 | ok       | ok       | ok    |
 
 [^1]: macOS does not recognize the composite device as an HID device
 

--- a/README.md
+++ b/README.md
@@ -135,14 +135,12 @@ sinowisp write \
 | ISP MD5                          | Windows  | macOS    | Linux |
 | -------------------------------- | -------- | -------- | ----- |
 | 13df4ce2933f9654ffef80d6a3c27199 | ok       | ok       | ok    |
-| 2d169670eae0d36eae8188562c1f66e8 | ok       | ?        | ok    |
+| 2d169670eae0d36eae8188562c1f66e8 | ok       | ok       | ok    |
 | 3e0ebd0c440af5236d7ff8872343f85d | ok       | ok       | ok    |
 | 571ea8b315654c39046e4cc3b1e43777 | ok       | ok       | ok    |
 | 6dac0d2288f2a3d83b5703d979c114ec | ok       | ?        | ?     |
-| cfc8661da8c9d7e351b36c0a763426aa | ok       | fail[^1] | ok    |
+| cfc8661da8c9d7e351b36c0a763426aa | ok       | ok       | ok    |
 | e57490acebcaabfcff84a0ff013955d9 | ok       | ok       | ok    |
-
-[^1]: macOS does not recognize the composite device as an HID device
 
 ## Prerequisites
 


### PR DESCRIPTION
Verified against real hardware, all reads byte-identical to the known-good bootloaders:

- `13df4ce2` (Trust GXT 960): Windows and macOS
- `571ea8b3` (Glorious Model O): macOS
- `e57490ac` (Genesis Thor 300): macOS
- `2d169670` and `cfc8661d`: macOS, by stitching each into a full-flash image and writing it to a `nuphy-air60` over ICP

Every `fail[^1]` row is now resolved, so the orphaned footnote is removed with them. Those rows predate #152, which added the HID backend fallback that makes these work on macOS.
